### PR TITLE
PREB-3 Allow bpid call without parameters

### DIFF
--- a/modules/userId/britepoolIdSystem.js
+++ b/modules/userId/britepoolIdSystem.js
@@ -38,7 +38,9 @@ export const britepoolIdSubmodule = {
       // First let's rule out that the response is not a function
       if (typeof getterResponse !== 'function') {
         // Optimization to return value from getter
-        return britepoolIdSubmodule.normalizeValue(getterResponse);
+        return {
+          id: britepoolIdSubmodule.normalizeValue(getterResponse)
+        };
       }
     }
     // Return for async operation

--- a/modules/userId/britepoolIdSystem.js
+++ b/modules/userId/britepoolIdSystem.js
@@ -69,7 +69,7 @@ export const britepoolIdSubmodule = {
               if (error !== '') utils.logError(error);
               callback();
             }
-          }, JSON.stringify(params), { customHeaders: headers, contentType: 'application/json', method: 'POST' });
+          }, JSON.stringify(params), { customHeaders: headers, contentType: 'application/json', method: 'POST', withCredentials: true });
         }
       }
     }
@@ -90,12 +90,10 @@ export const britepoolIdSubmodule = {
         return { errors };
       }
     } else {
-      if (typeof params.api_key !== 'string' || Object.keys(params).length < 2) {
-        errors.push('User ID - britepoolId submodule requires api_key and at least one identifier to be defined');
-        return { errors };
+      if (params.api_key) {
+        // Add x-api-key into the header
+        headers['x-api-key'] = params.api_key;
       }
-      // Add x-api-key into the header
-      headers['x-api-key'] = params.api_key;
     }
     const url = params.url || 'https://api.britepool.com/v1/britepool/id';
     const getter = params.getter;

--- a/test/spec/modules/britepoolIdSystem_spec.js
+++ b/test/spec/modules/britepoolIdSystem_spec.js
@@ -30,9 +30,10 @@ describe('BritePool Submodule', () => {
     expect(params).to.eql({ aaid, idfa });
   });
 
-  it('fails without api_key', () => {
+  it('allows call without api_key', () => {
     const { params, headers, url, errors } = britepoolIdSubmodule.createParams({ aaid, idfa });
-    expect(errors.length).to.equal(1);
+    expect(params).to.eql({ aaid, idfa });
+    expect(errors.length).to.equal(0);
   });
 
   it('test url override', () => {


### PR DESCRIPTION
* Allow the britepool call without parameters (identifiers)
* Fix immediate value return to return within id key